### PR TITLE
Corrected `run.sh` permission issue and added usage example to readme.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM alpine:latest
 
 COPY run.sh /run.sh
 
+RUN chmod +x /run.sh
+
 VOLUME /mnt
 
 CMD ["/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,4 @@
 FROM alpine:latest
-
-COPY run.sh /run.sh
-
-RUN chmod +x /run.sh
-
 VOLUME /mnt
 
-CMD ["/run.sh"]
+CMD echo 1 > /mnt/vm/overcommit_memory

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Enable overcommitting to memory on a host running a redis container.  See the [R
  * Mount a volume on this container with `-v /proc/sys/vm:/mnt/vm` and run with `--privileged`
  * Reboot host
  
+```sh
+docker run https://github.com/bkuhl/redis-overcommit-on-host.git -v /proc/sys/vm:/mnt/vm --privileged
+```
+ 
 ### Why do this in a container?
 
 I'm a big fan of a container's ability to serve as documentation for any special changes that need to happen on the host for a container to run right.  

--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@ Enable overcommitting to memory on a host running a redis container.  See the [R
 # How to use
 
  * Schedule this container to run alongside any host with a running `redis` container.
- * Mount a volume on this container with `-v /proc/sys/vm:/mnt/vm` and run with `--privileged`
- * Reboot host
- 
+ * Pull in this repository and run the container:
 ```sh
 docker run https://github.com/bkuhl/redis-overcommit-on-host.git -v /proc/sys/vm:/mnt/vm --privileged
 ```
+ * Reboot host
+ 
+
  
 ### Why do this in a container?
 

--- a/README.md
+++ b/README.md
@@ -3,14 +3,31 @@
 Enable overcommitting to memory on a host running a redis container.  See the [Redis documentation](https://redis.io/topics/faq#background-saving-fails-with-a-fork-error-under-linux-even-if-i-have-a-lot-of-free-ram) for more information.
 
 # How to use
+Schedule this container to run alongside any host with a running `redis` container.
 
- * Schedule this container to run alongside any host with a running `redis` container.
- * Pull in this repository and run the container:
+##### Command line
 ```sh
 docker run https://github.com/bkuhl/redis-overcommit-on-host.git -v /proc/sys/vm:/mnt/vm --privileged
 ```
- * Reboot host
- 
+
+##### Docker Compose
+```yml
+version: '3'
+
+services:
+  # redis-overcommit-on-host
+  redis-overcommit:
+    build: https://github.com/bkuhl/redis-overcommit-on-host.git
+    restart: 'no'
+    privileged: true
+
+  # Your existing Redis service
+  redis:
+    image: 'redis'
+    restart: 'always'
+    depends_on:
+      - redis-overcommit
+```
 
  
 ### Why do this in a container?

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ services:
     build: https://github.com/bkuhl/redis-overcommit-on-host.git
     restart: 'no'
     privileged: true
+    volumes:
+      - /proc/sys/vm:/mnt/vm
 
   # Your existing Redis service
   redis:

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-RUN echo 1 > /mnt/vm/overcommit_memory


### PR DESCRIPTION
The `run.sh` script does not come with proper permissions out of the box, resulting in a "permission denied" exception when executed by the container.

This PR moves the functionality of `run.sh` into the Dockerfile and updates the documentation with a handy copy-paste'able line for running the container.

